### PR TITLE
STC-1618 - Updated the website preview box according mockup

### DIFF
--- a/src/grid/style.scss
+++ b/src/grid/style.scss
@@ -197,7 +197,7 @@
 			align-items: center;
 		}
 		& > svg {
-			width: 32px;
+			width: 25px;
 			height: auto;
 			margin: 5px;
 			border-radius: 50%;

--- a/src/grid/style.scss
+++ b/src/grid/style.scss
@@ -192,11 +192,19 @@
 	justify-content: center;
 	align-items: center;
 	span {
+		&:last-of-type {
+			display: flex;
+			align-items: center;
+		}
 		& > svg {
 			width: 32px;
 			height: auto;
 			margin: 5px;
 			border-radius: 50%;
+
+			&:last-of-type {
+				margin-right: 0;
+			}
 		}
 	}
 }

--- a/src/grid/style.scss
+++ b/src/grid/style.scss
@@ -154,14 +154,15 @@
 }
 
 .stc-grid-item-hover-button {
-	padding: 7px 25px;
+	padding: 7px 42px;
 	background: var(--stc-color-accent);
-	font-size: 18px;
-	font-weight: 600;
+	font-size: var(--stc-font-size-s);
+	font-weight: var(--stc-font-weight-extra-bold);
 	color: var(--stc-color-white);
 	line-height: 24px;
 	text-decoration: none !important;
-	border-radius: var(--stc-border-radius-2);
+	border-radius: var(--stc-border-radius-4);
+	box-shadow: 0px 10px 10px -5px rgba(86, 74, 151, 0.5) !important;
 	&:hover {
 		background: var(--stc-color-accent-hover);
 		color: var(--stc-color-white);

--- a/src/grid/style.scss
+++ b/src/grid/style.scss
@@ -177,7 +177,7 @@
 	height: auto;
 	visibility: hidden;
 	opacity: 0;
-	top: 45%;
+	top: 35%;
 	bottom: 50%;
 	font-weight: 600;
 	font-size: 16px;

--- a/src/grid/style.scss
+++ b/src/grid/style.scss
@@ -104,6 +104,9 @@
 		.stc-grid-item-blur{
 			opacity: 1;
 		}
+		.stc-grid-site-screenshot {
+			filter: blur(2px);
+		}
 	}
 }
 

--- a/src/grid/style.scss
+++ b/src/grid/style.scss
@@ -195,6 +195,7 @@
 		&:last-of-type {
 			display: flex;
 			align-items: center;
+			padding-left: 20px;
 		}
 		& > svg {
 			width: 25px;

--- a/src/style.scss
+++ b/src/style.scss
@@ -2,6 +2,7 @@ body {
 	/* Colors */
     --stc-color-accent: #2563EB;
     --stc-color-accent-hover: #1D4ED8;
+    --stc-color-accent-2: #492CDD;
     --stc-color-heading: #1F2937;
     --stc-color-body: #4B5563;
     --stc-color-light-gray: #E5E7EB;
@@ -36,6 +37,7 @@ body {
 
     /** Border */
     --stc-border-color: #D1D5DB;
+    --stc-border-color-2: #C4C7CC;
     --stc-border-radius-5: 5px;
     --stc-border-radius-4: 4px;
     --stc-border-radius-3: 3px;


### PR DESCRIPTION
### Description
- fix: hover content aligned centered
- Center-aligned page builder logo with available text
- Resized available page builders logo to 25px
- fix: padding
- fix: preview button styling
- blur the image on hover
- fix: pagination button styling

### Screenshots
- https://d.pr/i/gaC0qh

### Types of changes
- UI fix.

### How has this been tested?
- Please refer to point 12 of [this stylesheet.](https://docs.google.com/spreadsheets/d/1RIlX060crQsR-PC1GZ3YrsphNu6hKIxQaXFnDjjU4Xw/edit#gid=0)

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
