### PR TITLE
chore: add Claude Code scaffolding and internal docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "autoCompactThreshold": 50,
+
+  "permissions": {
+    "allow": [
+      "Bash(npm run start)",
+      "Bash(npm run build)",
+      "Bash(npm run lint:js)",
+      "Bash(npm run lint:js:fix)",
+      "Bash(npm run lint:css)",
+      "Bash(npm run format:js)",
+      "Bash(npm run check-engines)",
+      "Bash(npm run check-licenses)",
+      "Bash(git status)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git branch *)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Bash(rm -rf *)",
+      "Bash(git push * --force)",
+      "Bash(git add .env)"
+    ]
+  },
+
+  "spinnerVerbs": {
+    "mode": "append",
+    "verbs": [
+      "Analyzing patterns",
+      "Reviewing architecture",
+      "Running checks",
+      "Scanning for issues",
+      "Validating structure"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /vendor/
 .DS_Store
 src/.DS_Store
+
+# Claude Code
+.claude/settings.local.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 /src
 .babelrc
 webpack.config.js
+.claude
+CLAUDE.md
+internal-docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Starter Templates Components
+
+React component library for the Starter Templates WordPress plugin by Brainstorm Force.
+
+## Tech Stack
+
+- **Frontend:** React 18 (JSX) with SCSS
+- **Build:** Webpack 5 (custom config, not wp-scripts build)
+- **Linting:** @wordpress/eslint-plugin, wp-prettier
+- **Package:** Published as `@brainstormforce/starter-templates-components`
+- **Node:** 18.15.0 (enforced via Volta + engines)
+
+## Commands
+
+```bash
+npm run start          # Watch mode (webpack --mode development)
+npm run build          # Production build (webpack --mode production)
+npm run lint:js        # ESLint on src/
+npm run lint:js:fix    # ESLint with auto-fix
+npm run lint:css       # Stylelint via wp-scripts
+npm run format:js      # Prettier via wp-scripts
+```
+
+## Architecture
+
+This is a **component library** (not a standalone plugin). It exports React components consumed by the Starter Templates plugin.
+
+- `src/index.js` — Entry point, re-exports all components
+- `src/<component>/` — Each component in its own directory (JS + SCSS)
+- `build/index.js` — Webpack output (commonjs2), React is external
+- Components: Button, Grid, Search, CategoryList, ToggleDropdown, Logo, Tooltip, SuggestionList, Toaster, SiteOrder, SiteType, NoResultFound, MegaMenu, PremiumBadge, SiteBusinessType
+
+## Conventions
+
+- Follow WordPress coding standards for JS (@wordpress/eslint-plugin)
+- Use wp-prettier for formatting
+- SCSS for styling (style-loader + css-loader + sass-loader pipeline)
+- React is marked as external in webpack — do not bundle it
+- Each component gets its own directory under `src/`
+
+## Gotchas
+
+- The `.npmignore` excludes `/src` from the published package — only `build/` is distributed
+- Node version is pinned to 18.15.0 via Volta — use that exact version
+- `react` is externalized in webpack config — the consuming plugin provides React

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ React component library for the Starter Templates WordPress plugin by Brainstorm
 - **Linting:** @wordpress/eslint-plugin, wp-prettier
 - **Package:** Published as `@brainstormforce/starter-templates-components`
 - **Node:** 18.15.0 (enforced via Volta + engines)
+- **PHP tooling:** composer.json for PHPCompatibility checks (vendor/)
 
 ## Commands
 
@@ -19,27 +20,73 @@ npm run lint:js        # ESLint on src/
 npm run lint:js:fix    # ESLint with auto-fix
 npm run lint:css       # Stylelint via wp-scripts
 npm run format:js      # Prettier via wp-scripts
+npm run check-engines  # Verify Node/npm versions
+npm run check-licenses # Check dependency licenses
 ```
 
 ## Architecture
 
 This is a **component library** (not a standalone plugin). It exports React components consumed by the Starter Templates plugin.
 
-- `src/index.js` — Entry point, re-exports all components
+- `src/index.js` — Entry point, re-exports all 15 components
 - `src/<component>/` — Each component in its own directory (JS + SCSS)
+- `src/icons.js` — Shared SVG icon constants (ICONS object)
+- `src/style.scss` — Global CSS custom properties (design tokens on `body`)
+- `src/animations.scss` — Shared keyframe animation
+- `index.js` (root) — Re-exports from `./src/index.js` for dev convenience
 - `build/index.js` — Webpack output (commonjs2), React is external
-- Components: Button, Grid, Search, CategoryList, ToggleDropdown, Logo, Tooltip, SuggestionList, Toaster, SiteOrder, SiteType, NoResultFound, MegaMenu, PremiumBadge, SiteBusinessType
+
+Components: Button, Grid, Search, CategoryList, ToggleDropdown, Logo, Tooltip, SuggestionList, Toaster, SiteOrder, SiteType, NoResultFound, MegaMenu, PremiumBadge, SiteBusinessType
 
 ## Conventions
 
 - Follow WordPress coding standards for JS (@wordpress/eslint-plugin)
-- Use wp-prettier for formatting
+- Use wp-prettier for formatting (WordPress-style spacing: `( { prop } )`)
+- Arrow/const functions required — `func-style: ["error", "expression"]`
 - SCSS for styling (style-loader + css-loader + sass-loader pipeline)
 - React is marked as external in webpack — do not bundle it
 - Each component gets its own directory under `src/`
+- All CSS classes use `stc-` prefix (Starter Templates Components)
+- Guard all event callbacks: `if ( 'function' === typeof onClick ) { onClick( event, data ); }`
+- Components expose CSS custom properties with fallbacks for consuming plugin overrides
+
+### ESLint Disabled Rules (`.eslintrc`)
+
+- `react/prop-types: off` — No PropTypes validation; refer to function signatures
+- `jsx-a11y/no-static-element-interactions: off` — Click handlers on divs accepted
+- `jsx-a11y/click-events-have-key-events: off` — Keyboard accessibility not enforced
+- `react-hooks/exhaustive-deps: off` — Dependency arrays manually managed
+
+## CSS Architecture
+
+- Design tokens defined as `--stc-*` CSS custom properties on `body` in `src/style.scss`
+- Per-component SCSS imports global tokens via `@import url('../style.scss')`
+- **Style injection:** CSS is injected at runtime via style-loader — no separate CSS file. Importing any component injects ALL styles.
+- Components expose customization via CSS vars with fallbacks (e.g., `var(--stc-search-input-height, 44px)`)
 
 ## Gotchas
 
 - The `.npmignore` excludes `/src` from the published package — only `build/` is distributed
 - Node version is pinned to 18.15.0 via Volta — use that exact version
-- `react` is externalized in webpack config — the consuming plugin provides React
+- `react` is externalized in webpack config — the consuming plugin provides React at runtime
+- `src/suggession-list/` directory is **misspelled** (should be "suggestion") — do not rename without updating all imports
+- Toaster uses `st-toaster` CSS prefix instead of `stc-` — inconsistent with other components
+- `src/toaster/index.js` calls `setTimeout` directly in component body (not in `useEffect`) — anti-pattern
+- `src/suggession-list/index.js` uses `dangerouslySetInnerHTML` for search highlighting
+- `src/search/index.js` uses `document.getElementsByClassName` instead of the existing React ref
+- Importing any component causes ALL styles to be injected (no CSS tree-shaking)
+- `src/grid/index.js` has an `enableNewUi` feature flag toggling legacy vs. new rendering
+
+## Runtime Dependencies
+
+- `@wordpress/html-entities` — `decodeEntities()` for safe HTML entity decoding
+- `@wordpress/i18n` — `__()` and `sprintf()` for translation-ready strings
+- `use-debounce` — `useDebouncedCallback` in Search component
+
+## Internal Docs
+
+See `internal-docs/` for detailed documentation:
+- `README.md` — Project overview, component index
+- `architecture.md` — Component hierarchy, data flow, build pipeline, CSS architecture
+- `codebase-map.md` — Annotated directory tree with line numbers
+- `ai-agent-guide.md` — Code patterns, pitfalls, props reference, component creation checklist

--- a/internal-docs/README.md
+++ b/internal-docs/README.md
@@ -1,0 +1,66 @@
+# Starter Templates Components -- Internal Documentation
+
+## Project Overview
+
+`@brainstormforce/starter-templates-components` is a React component library that provides UI building blocks for the **Starter Templates** WordPress plugin by Brainstorm Force. It is not a standalone plugin -- it is consumed as a dependency by the parent plugin, which provides React at runtime.
+
+The library exports **15 React components** covering template browsing, filtering, search, and navigation UI. It ships as a single CommonJS2 bundle (`build/index.js`) built by Webpack 5.
+
+## Key Facts
+
+| Fact | Value |
+|---|---|
+| Package name | `@brainstormforce/starter-templates-components` |
+| Entry point (source) | `src/index.js` |
+| Entry point (built) | `build/index.js` |
+| Output format | CommonJS2 (`libraryTarget: "commonjs2"`) |
+| React | External (provided by consuming plugin) |
+| Node version | 18.15.0 (Volta-pinned) |
+| Styling | SCSS, injected at runtime via style-loader |
+| Linting | `@wordpress/eslint-plugin` + `wp-prettier` |
+| Components | 15 |
+
+## Quick Start
+
+```bash
+# Install dependencies (use Node 18.15.0)
+npm install
+
+# Development (watch mode)
+npm run start
+
+# Production build
+npm run build
+
+# Lint
+npm run lint:js
+npm run lint:js:fix
+npm run lint:css
+npm run format:js
+```
+
+## Exported Components
+
+| Component | Purpose |
+|---|---|
+| **Button** | Basic styled button wrapper |
+| **Grid** | Template card grid with screenshots, favorites, premium badges |
+| **Search** | Debounced search input with API integration |
+| **CategoryList** | Horizontal category filter tabs with overflow dropdown |
+| **ToggleDropdown** | Generic dropdown selector with logo/image support |
+| **Logo** | Image + text logo display |
+| **Tooltip** | Hover tooltip with auto-hide |
+| **SuggestionList** | Search autocomplete suggestion list with highlighting |
+| **Toaster** | Positioned toast notification with auto-dismiss |
+| **SiteOrder** | Pre-configured ToggleDropdown for Popular/Latest sorting |
+| **SiteType** | Pre-configured ToggleDropdown for All/Premium filtering |
+| **NoResultFound** | Empty-state message for failed searches |
+| **MegaMenu** | Responsive multi-level navigation menu |
+| **PremiumBadge** | "Premium" label badge |
+| **SiteBusinessType** | MegaMenu pre-loaded with business category data |
+
+## Documentation Index
+
+- [architecture.md](./architecture.md) -- High-level architecture, component hierarchy, data flow, build pipeline
+- [codebase-map.md](./codebase-map.md) -- Directory tree with descriptions of every key file
+- [ai-agent-guide.md](./ai-agent-guide.md) -- Key code locations, patterns, pitfalls, component creation checklist

--- a/internal-docs/ai-agent-guide.md
+++ b/internal-docs/ai-agent-guide.md
@@ -1,0 +1,306 @@
+# AI Agent Guide
+
+Practical reference for AI agents working on this codebase.
+
+## Key Code Locations
+
+| What | Where |
+|---|---|
+| All component exports | `src/index.js` (lines 1-33) |
+| Shared SVG icons | `src/icons.js` -- exports `ICONS` object with keys: search, cross, dropdown, favorite, close, success, error, toggle |
+| Design tokens (CSS vars) | `src/style.scss` (lines 1-47) -- all `--stc-*` custom properties |
+| Shared animation | `src/animations.scss` -- single `@keyframes stc-visible` |
+| Webpack config | `webpack.config.js` (34 lines) |
+| ESLint rules | `.eslintrc` (59 lines) |
+| Babel presets | `.babelrc` (3 lines) |
+| Root re-export | `index.js` (7 lines) -- re-exports from `./src/index.js` |
+| Static data | `src/site-business-type/mega-menu-content.json` -- business category tree |
+
+## Common Code Patterns
+
+### 1. Component File Structure
+
+Every component follows this pattern:
+
+```javascript
+// External Dependencies.
+import React from 'react';
+
+// Internal Dependencies.
+import './style.scss';
+
+const ComponentName = ( { prop1, prop2 } ) => {
+    // Component logic
+    return ( /* JSX */ );
+};
+
+export default ComponentName;
+// or: export default memo( ComponentName );
+```
+
+**Note the WordPress-style spacing**: spaces inside parentheses `( { prop } )`, spaces inside JSX expressions `{ value }`, spaces inside CSS `var()` calls `var( --stc-color-accent )`.
+
+### 2. Callback Safety Pattern
+
+All event callbacks use this guard pattern before invoking:
+
+```javascript
+if ( 'function' === typeof onClick ) {
+    onClick( event, data );
+}
+```
+
+This appears in: Grid, Search, CategoryList, ToggleDropdown, Logo, SuggestionList, SiteOrder, SiteType, SiteBusinessType, MegaMenu.
+
+### 3. Empty-State Guard
+
+Components that receive `options` arrays guard against empty arrays:
+
+```javascript
+if ( ! options.length ) {
+    return '';
+}
+```
+
+Used in: Grid (line 25), ToggleDropdown (line 60), SuggestionList (line 7).
+
+### 4. Memoization
+
+Three components wrap their export in `React.memo()`:
+- Search (`export default memo( Search )` -- line 101)
+- CategoryList (`export default memo( CategoryList )` -- line 99)
+- SuggestionList (`export default memo( SuggestionList )` -- line 38)
+- SiteOrder (`export default memo( SiteOrder )` -- line 29)
+- SiteType (`export default memo( SiteType )` -- line 29)
+
+### 5. SCSS Import Pattern
+
+Each component's SCSS file imports the global tokens:
+
+```scss
+// Core CSS.
+@import url('../style.scss');
+```
+
+Some also import animations: `@import '../animations.scss';` (Grid's style.scss).
+
+### 6. Internal Imports Between Components
+
+Components import siblings via the package index:
+
+```javascript
+import { ToggleDropdown } from '..';       // CategoryList
+import { ToggleDropdown } from '../index.js'; // SiteOrder, SiteType
+import { Logo } from '../index';            // ToggleDropdown
+import { PremiumBadge } from '..';          // Grid
+import MegaMenu from '../mega-menu';        // SiteBusinessType (direct import)
+```
+
+### 7. CSS Custom Property Overrides
+
+Components expose customization points via CSS custom properties with fallback values:
+
+```scss
+padding: var( --stc-toggle-dropdown-selected-padding, 6px 10px 6px 16px );
+```
+
+The consuming plugin can override these without touching source SCSS.
+
+## Pitfalls and Gotchas
+
+### 1. Misspelled Directory Name
+The `suggession-list/` directory is misspelled (should be "suggestion"). The import in `src/index.js` line 8 uses `'./suggession-list'`. Do not rename without updating all references.
+
+### 2. Inconsistent CSS Prefix
+Toaster uses `st-toaster` class prefix (line 53 of `src/toaster/index.js`), while all other components use `stc-` prefix. The Toaster SCSS also uses `--st-*` CSS vars instead of `--stc-*`.
+
+### 3. setTimeout in Render (Toaster)
+`src/toaster/index.js` lines 29-31 call `setTimeout` directly in the component body (not in useEffect). This creates a new timeout on every render, which is a known anti-pattern that can cause state updates on unmounted components.
+
+### 4. dangerouslySetInnerHTML (SuggestionList)
+`src/suggession-list/index.js` line 23 uses `dangerouslySetInnerHTML` to render highlighted search terms. The input is processed through `decodeEntities` and regex replacement, but this is worth noting for security reviews.
+
+### 5. Direct DOM Access (Search)
+`src/search/index.js` line 89 uses `document.getElementsByClassName('stc-search-input')[0].focus()` instead of the React ref that is already defined (`inputRef`). This is fragile if multiple Search components exist on the same page.
+
+### 6. Body Click Listener (ToggleDropdown)
+`src/toggle-dropdown/index.js` lines 50-58 attach a click event listener to `document.querySelector('body')` for outside-click detection. This uses `addEventListener`/`removeEventListener` directly.
+
+### 7. No PropTypes
+`react/prop-types` is explicitly disabled in `.eslintrc` (line 47). No runtime prop validation exists. Refer to the component function signatures for expected props.
+
+### 8. Style Injection Side Effect
+Importing any component causes ALL styles (including global `style.scss`) to be injected into the DOM via style-loader. There is no tree-shaking for CSS.
+
+### 9. React External
+`react` is externalized in webpack (`externals: { react: "react" }`). The consuming environment MUST provide React via `require("react")`. If it does not, the bundle will fail at runtime.
+
+### 10. `enableNewUi` Flag in Grid
+`src/grid/index.js` has a prop `enableNewUi` that switches between two rendering modes (legacy direct-click screenshots vs. new link-wrapped screenshots with blur overlay). This is a feature flag pattern.
+
+## Component Props Reference
+
+### Button
+```
+children: ReactNode
+```
+
+### Grid
+```
+className: string
+column: number|string (1-6, default '3')
+options: Array<{ id, title, image, badge?, desc?, link?, livelink? }>
+onClick: (event, item) => void
+hasFavorite: boolean
+onFavoriteClick: (event, item, newState) => void
+favoriteList: string[] (format: 'id-{id}')
+buttonLabel: string
+livePreview: string
+enableNewUi: boolean
+```
+
+### Search
+```
+apiUrl: string
+onSearchResult: (response, searchedText) => void
+beforeSearchResult: () => void
+onSearch: (event, value) => void
+value: string
+placeholder: string
+onKeyUp: (event) => void
+```
+
+### CategoryList
+```
+options: Array<{ id, name }>
+value: string|number
+onClick: (event, category) => void
+limit: number
+```
+
+### ToggleDropdown
+```
+label: string
+options: Array<{ id, title, image?, extraText? }>
+className: string
+value: string|number
+onClick: (event, option) => void
+icon: ReactNode
+dismissAiPopup: () => void
+```
+
+### Logo
+```
+className: string
+text: string
+src: string (image URL)
+alt: string
+onClick: (event) => void
+href: string (wraps image in anchor)
+extraText: string
+```
+
+### Tooltip
+```
+children: ReactNode
+content: ReactNode|string
+```
+
+### SuggestionList
+```
+value: string (current search text, used for highlighting)
+options: string[]
+onClick: (event, option) => void
+```
+
+### Toaster
+```
+type: 'success'|'error'
+message: string|ReactNode
+autoHideDuration: number (seconds, default 3)
+topLeft/topRight/topCenter/bottomLeft/bottomRight/bottomCenter/leftCenter: boolean
+style: object
+```
+
+### SiteOrder
+```
+value: string ('popular'|'latest')
+onClick: (event, order) => void
+```
+
+### SiteType
+```
+value: string (''|'agency-mini')
+onClick: (event, type) => void
+```
+
+### NoResultFound
+```
+searchTerm: string
+```
+
+### MegaMenu
+```
+options: Array<{ ID, title, parent, children?: Array<...> }>
+parent: number|string (active parent ID)
+menu: number|string (active menu item ID)
+onClick: (event, parentOption, childItem) => void
+```
+
+### PremiumBadge
+```
+badge: string (defaults to 'Premium')
+```
+
+### SiteBusinessType
+```
+parent: number|string
+menu: number|string
+onClick: (event, option, childItem) => void
+```
+
+## Component Creation Checklist
+
+When adding a new component to this library:
+
+1. **Create directory**: `src/<component-name>/` (use kebab-case)
+
+2. **Create component file**: `src/<component-name>/index.js`
+   - Import React
+   - Import `./style.scss`
+   - Use `const` arrow function (enforced by `func-style: ["error", "expression"]`)
+   - Use WordPress-style spacing in JSX
+   - Guard callbacks with `'function' === typeof callback` pattern
+   - Export default (optionally wrapped in `memo()`)
+
+3. **Create style file**: `src/<component-name>/style.scss`
+   - Start with `@import url('../style.scss');`
+   - Use `stc-` prefix for all class names
+   - Use design token CSS vars from `style.scss` (e.g., `var(--stc-color-accent)`)
+   - Expose customization points as CSS custom properties with fallback values
+
+4. **Register export**: Add to `src/index.js`
+   - Add import line (alphabetical by path is not enforced but follow existing order)
+   - Add to the named export block
+
+5. **Register in root**: Add to `index.js` (root file)
+   - Add component name to the destructured re-export
+
+6. **If using shared icons**: Import `{ ICONS } from '../icons'` and reference by key
+
+7. **Build and verify**: Run `npm run build` then `npm run lint:js`
+
+## Editing Workflow
+
+```bash
+# Start watch mode for iterative development
+npm run start
+
+# After changes, lint
+npm run lint:js:fix
+
+# Final production build
+npm run build
+```
+
+The built output is `build/index.js`. The consuming Starter Templates plugin imports from the built file.

--- a/internal-docs/architecture.md
+++ b/internal-docs/architecture.md
@@ -1,0 +1,162 @@
+# Architecture
+
+## High-Level Overview
+
+```
+Consuming WordPress Plugin (Starter Templates)
+    |
+    |-- imports from @brainstormforce/starter-templates-components
+    |       |
+    |       build/index.js  (CommonJS2 bundle)
+    |           |
+    |           src/index.js  (named re-exports of all 15 components)
+    |               |
+    |               src/<component>/index.js  (each component)
+    |               src/<component>/style.scss (each component's styles)
+    |               src/icons.js              (shared SVG icon constants)
+    |               src/style.scss            (shared CSS custom properties)
+    |               src/animations.scss       (shared keyframe animations)
+```
+
+The library is a leaf dependency. It has no routing, no state management, and no side effects beyond injecting CSS via style-loader at import time.
+
+## Component Hierarchy
+
+Components are mostly flat and independent. The key internal dependency relationships are:
+
+```
+Grid
+  +-- Tooltip
+  +-- PremiumBadge
+  +-- ICONS (from icons.js)
+
+CategoryList
+  +-- ToggleDropdown (for "More" overflow items)
+
+ToggleDropdown
+  +-- Logo (renders image+text options)
+  +-- ICONS.dropdown
+
+Search
+  +-- ICONS.search, ICONS.cross
+
+SiteOrder
+  +-- ToggleDropdown (hardcoded Popular/Latest options)
+
+SiteType
+  +-- ToggleDropdown (hardcoded All/Premium options)
+
+SiteBusinessType
+  +-- MegaMenu (loaded with mega-menu-content.json)
+
+MegaMenu
+  +-- ICONS.toggle, ICONS.dropdown
+
+Toaster
+  +-- ICONS[type] (success/error), ICONS.close
+
+NoResultFound, Button, Logo, Tooltip, PremiumBadge, SuggestionList
+  (standalone, no internal component dependencies)
+```
+
+## Data Flow
+
+All components are **controlled** or **callback-driven**. There is no internal global state. The consuming plugin owns all state and passes it as props.
+
+Common patterns:
+- **value + onClick**: CategoryList, ToggleDropdown, SiteOrder, SiteType, SiteBusinessType, MegaMenu, SuggestionList
+- **value + onSearch + apiUrl + onSearchResult**: Search (fetches from `apiUrl` on debounced input change, returns results via `onSearchResult` callback)
+- **Display-only props**: Grid receives `options` array of template objects; Toaster receives `type`/`message`
+
+The Search component is the only component that performs network requests (via `fetch(apiUrl)`). All other components are purely presentational.
+
+## Build Pipeline
+
+### Webpack Configuration (`webpack.config.js`)
+
+```
+Entry:    src/index.js
+Output:   build/index.js (commonjs2)
+External: react (not bundled)
+
+Loaders:
+  .scss/.sass  --> sass-loader --> css-loader --> style-loader (injected into DOM at runtime)
+  .js/.jsx     --> babel-loader (presets: @babel/preset-react, @babel/preset-env)
+```
+
+Key implications:
+1. **CSS is injected at runtime** via style-loader. There is no separate CSS file. Importing the library automatically injects all component styles into the page `<head>`.
+2. **React is external**. The consuming environment must provide React. The bundle references `require("react")`.
+3. **No code splitting**. Everything is bundled into a single `build/index.js`.
+
+### Babel Configuration (`.babelrc`)
+
+```json
+{
+    "presets": ["@babel/preset-react", "@babel/preset-env"]
+}
+```
+
+### ESLint Configuration (`.eslintrc`)
+
+Extends `plugin:@wordpress/eslint-plugin/recommended` with WordPress coding standards. Notable disabled rules:
+- `react/prop-types: off` -- No PropTypes validation
+- `jsx-a11y/no-static-element-interactions: off` -- Click handlers on divs are accepted
+- `jsx-a11y/click-events-have-key-events: off` -- Keyboard accessibility not enforced
+- `react-hooks/exhaustive-deps: off` -- Dependency arrays are manually managed
+- `func-style: ["error", "expression"]` -- Arrow/const functions required, no function declarations
+
+### npm Scripts
+
+| Script | Command | Purpose |
+|---|---|---|
+| `start` | `webpack --watch --mode development` | Dev watch mode |
+| `build` | `webpack --mode production` | Production bundle |
+| `lint:js` | `wp-scripts lint-js ./src/` | ESLint check |
+| `lint:js:fix` | `wp-scripts lint-js ./src/ --fix` | ESLint auto-fix |
+| `lint:css` | `wp-scripts lint-style` | Stylelint |
+| `format:js` | `wp-scripts format-js` | Prettier |
+
+### Publishing
+
+The `.npmignore` file excludes `/src` from the published npm package -- only `build/` is distributed. The root `index.js` re-exports from `./src/index.js` for local development convenience.
+
+## CSS Architecture
+
+### Design Tokens (`src/style.scss`)
+
+All shared design values are defined as CSS custom properties on `body`:
+
+- **Colors**: `--stc-color-accent`, `--stc-color-heading`, `--stc-color-body`, etc.
+- **Font sizes**: `--stc-font-size-xxl` (30px) through `--stc-font-size-xxs` (11px)
+- **Font weights**: `--stc-font-weight-extra-bold` (600), `--stc-font-weight-bold` (500), `--stc-font-weight-normal` (400)
+- **Line heights**: `--stc-font-line-height-xl` (36px) through `--stc-font-line-height-xs` (20px)
+- **Borders**: `--stc-border-color`, `--stc-border-radius-1` through `--stc-border-radius-5`
+- **Backgrounds**: `--stc-background-primary`, `--stc-background-secondary`, `--stc-background-light`
+
+### CSS Class Naming
+
+All classes use the `stc-` prefix (Starter Templates Components). Examples:
+- `.stc-button`, `.stc-grid-wrap`, `.stc-search`, `.stc-category-list`
+- Exception: Toaster uses `st-toaster` prefix (inconsistent)
+
+### Per-Component Customization
+
+Several components expose CSS custom properties for the consuming plugin to override without modifying source. Examples:
+- Search: `--stc-search-input-border`, `--stc-search-input-height`, `--stc-search-input--focus-border`
+- ToggleDropdown: `--stc-toggle-dropdown-popup-min-width`, `--stc-toggle-dropdown-selected-padding`
+- SuggestionList: `--stc-suggestion-list-max-width`, `--stc-suggestion-list-position`
+- MegaMenu: `--stc-mega-menu-item-title-margin`, `--stc-mega-menu-group-margin`
+
+## Dependencies
+
+### Runtime Dependencies
+- `@wordpress/html-entities` -- `decodeEntities()` for safe HTML entity decoding in Grid, CategoryList, SuggestionList, NoResultFound
+- `@wordpress/i18n` -- `__()` and `sprintf()` for translation-ready strings
+- `react` / `react-dom` -- UI framework (externalized in bundle)
+- `use-debounce` -- `useDebouncedCallback` hook used in Search component
+
+### Dev Dependencies
+- Webpack 5 + loaders (babel-loader, css-loader, sass-loader, style-loader, svg-url-loader)
+- `@wordpress/scripts` -- provides wp-scripts CLI for linting/formatting
+- `@wordpress/eslint-plugin` + `wp-prettier` -- code quality tooling

--- a/internal-docs/codebase-map.md
+++ b/internal-docs/codebase-map.md
@@ -1,0 +1,108 @@
+# Codebase Map
+
+## Directory Tree
+
+```
+starter-templates-components/
+|-- package.json                 # Package config, scripts, dependencies
+|-- package-lock.json            # Lockfile
+|-- webpack.config.js            # Webpack 5 build config (entry, output, loaders, externals)
+|-- .babelrc                     # Babel presets (preset-react, preset-env)
+|-- .eslintrc                    # ESLint config extending @wordpress/eslint-plugin
+|-- .eslintignore                # ESLint ignore (contains "build")
+|-- .gitignore                   # Ignores node_modules, vendor, .DS_Store
+|-- .npmignore                   # Excludes /src from npm publish
+|-- composer.json                # PHP compatibility tooling (vendor/)
+|-- composer.lock                # PHP composer lockfile
+|-- index.js                     # Root re-export from ./src/index.js (dev convenience)
+|-- CLAUDE.md                    # AI agent context file
+|-- build/
+|   +-- index.js                 # Webpack production output (CommonJS2 bundle)
+|-- .github/                     # GitHub config (workflows, etc.)
+|-- src/
+|   |-- index.js                 # Main entry: imports and re-exports all 15 components
+|   |-- icons.js                 # Shared SVG icon constants (ICONS object)
+|   |-- style.scss               # Global CSS custom properties (design tokens on body)
+|   |-- animations.scss          # Shared keyframe animation (stc-visible)
+|   |
+|   |-- button/
+|   |   |-- index.js             # Button component (line 7-9): simple <button> wrapper
+|   |   +-- style.scss           # .stc-button styles using CSS vars
+|   |
+|   |-- grid/
+|   |   |-- index.js             # Grid component (lines 13-171): template card grid
+|   |   +-- style.scss           # CSS grid layout (1-6 columns), hover effects, responsive
+|   |
+|   |-- search/
+|   |   |-- index.js             # Search component (lines 10-98): debounced API search input
+|   |   +-- style.scss           # Search input + icon positioning
+|   |
+|   |-- category-list/
+|   |   |-- index.js             # CategoryList component (lines 10-97): horizontal filter tabs
+|   |   +-- style.scss           # Flexbox layout, active state styling
+|   |
+|   |-- toggle-dropdown/
+|   |   |-- index.js             # ToggleDropdown component (lines 9-135): generic dropdown
+|   |   +-- style.scss           # Dropdown popup positioning, active states
+|   |
+|   |-- logo/
+|   |   |-- index.js             # Logo component (lines 7-55): image + text display
+|   |   +-- style.scss           # Logo sizing via CSS vars (--stc-logo-width/height)
+|   |
+|   |-- tooltip/
+|   |   |-- index.js             # Tooltip component (lines 7-48): hover tooltip
+|   |   +-- style.scss           # Absolute positioning, visibility toggle
+|   |
+|   |-- suggession-list/         # NOTE: directory name is misspelled ("suggession" not "suggestion")
+|   |   |-- index.js             # SuggestionList component (lines 6-36): autocomplete dropdown
+|   |   +-- style.scss           # List item styles, highlight matching text
+|   |
+|   |-- toaster/
+|   |   |-- index.js             # Toaster component (lines 8-77): toast notification
+|   |   +-- style.scss           # Fixed positioning (7 positions), fade in/out animations
+|   |
+|   |-- site-order/
+|   |   +-- index.js             # SiteOrder component (lines 5-27): ToggleDropdown(Popular/Latest)
+|   |
+|   |-- site-type/
+|   |   +-- index.js             # SiteType component (lines 5-27): ToggleDropdown(All/Premium)
+|   |
+|   |-- no-result-found/
+|   |   |-- index.js             # NoResultFound component (lines 9-27): empty state message
+|   |   +-- style.scss           # Padded box with border and secondary background
+|   |
+|   |-- mega-menu/
+|   |   |-- index.js             # MegaMenu component (lines 5-268): responsive multi-level nav
+|   |   +-- style.scss           # Desktop flyouts, mobile hamburger, responsive breakpoints
+|   |
+|   |-- premium-badge/
+|   |   +-- index.js             # PremiumBadge component (lines 4-10): simple badge span
+|   |
+|   +-- site-business-type/
+|       |-- index.js             # SiteBusinessType component (lines 6-21): MegaMenu with JSON data
+|       |-- style.scss           # CSS var overrides for MegaMenu spacing
+|       +-- mega-menu-content.json  # Hardcoded business category hierarchy (455 lines)
+```
+
+## File Size Reference
+
+| File | Lines | Description |
+|---|---|---|
+| `src/mega-menu/index.js` | 270 | Largest component (3-level responsive menu) |
+| `src/mega-menu/style.scss` | 276 | Largest stylesheet (desktop + mobile layouts) |
+| `src/grid/index.js` | 173 | Second largest (template card grid) |
+| `src/grid/style.scss` | 232 | Grid layout, hover effects, responsive breakpoints |
+| `src/toggle-dropdown/index.js` | 135 | Dropdown with body click-outside-to-close |
+| `src/search/index.js` | 101 | Debounced search with API fetch |
+| `src/site-business-type/mega-menu-content.json` | 455 | Static business category data |
+| `src/icons.js` | 95 | 8 SVG icons as JSX constants |
+| `src/style.scss` | 47 | Design token definitions |
+| `src/button/index.js` | 11 | Smallest component |
+
+## Components Without Dedicated SCSS
+
+These components have no `style.scss` file in their directory:
+
+- **SiteOrder** (`src/site-order/`) -- uses ToggleDropdown styles
+- **SiteType** (`src/site-type/`) -- uses ToggleDropdown styles
+- **PremiumBadge** (`src/premium-badge/`) -- styled by `.stc-grid-item-badge` in Grid's SCSS


### PR DESCRIPTION
## Summary

Set up Claude Code project config and internal documentation for developer onboarding and AI agent understanding.

## What's Included

### Claude Code Config
- `CLAUDE.md` — Project context, commands, conventions, CSS architecture, gotchas, runtime deps
- `.claude/settings.json` — Pre-approved tool permissions for lint/build/git commands

### Internal Documentation
- `internal-docs/README.md` — Project overview, quick start, component index
- `internal-docs/architecture.md` — Component hierarchy, data flow, build pipeline, CSS architecture
- `internal-docs/codebase-map.md` — Annotated directory tree with line numbers
- `internal-docs/ai-agent-guide.md` — Code patterns, pitfalls, props reference, component creation checklist

### Build Exclusions
- `.gitignore` — Added `.claude/settings.local.json`
- `.npmignore` — Added `.claude`, `CLAUDE.md`, `internal-docs` (excluded from npm publish)

## Notes
- All doc content derived from actual code (not guessed)
- `internal-docs/` is excluded from production builds
- No functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)